### PR TITLE
Padを表示できるようにしてみた。

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <script type="text/javascript" src="src/enchant.js"></script>
+    <script type="text/javascript" src="src/plugins/ui.enchant.js"></script>
     <script type="text/javascript" src="main.js"></script>
     <style type="text/css">
         body {

--- a/main.js
+++ b/main.js
@@ -13,27 +13,34 @@ window.onload = function() {
   var tairyoku = 500;
   var sound1;
 
-  game.preload("end.png");
-  game.preload("pad.png");
-  game.preload("map0.png"); game.preload("map1.png");
-  game.preload("map2.png");
-  game.preload(['icon0.png']);
-  game.preload(['chara1.png']);
-  game.preload("chara5.png");
-  game.preload("chara6.png");
-  game.preload("chara7.png");
-  game.preload(['beam.mp3']);
-  game.preload(['kowai.mp3']);
-  game.preload(['music.mp3'])
-  game.preload(['music2.mp3']);
-  game.preload(['sword.mp3']);
-  game.preload(['sword2.mp3']);
-  game.preload(['sword3.mp3']);
-  game.preload(['break.mp3']);
-  game.preload(['break2.mp3']);
-  game.preload('player.png', 'pad.png');
+  // 画像のpreload
+  game.preload([
+    "end.png",
+    "pad.png",
+    "map0.png",
+    "map1.png",
+    "map2.png",
+    'icon0.png',
+    'chara1.png',
+    "chara5.png",
+    "chara6.png",
+    "chara7.png",
+//    'player.png',
+    'pad.png'
+  ]);
 
-
+  // SE,BGMのpreload
+  game.preload([
+    'beam.mp3',
+    'kowai.mp3',
+    'music.mp3',
+    'music2.mp3',
+    'sword.mp3',
+    'sword2.mp3',
+    'sword3.mp3',
+    'break.mp3',
+    'break2.mp3'
+  ]);
 
   game.onload = function() {
 
@@ -225,8 +232,8 @@ window.onload = function() {
       // バーチャルキーパッドを生成
 	    var pad = new Pad();
 	    pad.moveTo(0, 220);
-	    scene.addChild(pad);
-      player.addEventListener('enterframe', function(e) {
+	    game.rootScene.addChild(pad);
+      game.rootScene.addEventListener('enterframe', function(e) {
 			if (game.input.left) this.x -= 1.0;
 			if (game.input.right) this.x += 1.0;
 			if (game.input.up) this.y -= 1.0;


### PR DESCRIPTION
- パッドを表示できるように修正。（パッド表示するだけ）

Padが表示されていなかった原因は主に２つです。
1つはindex.htmlにPadを使うためのファイル（プラグイン）を読み込む必要があるので、index.htmlに
```
<script type="text/javascript" src="src/plugins/ui.enchant.js"></script>
```
を追加しました。

他にもいろいろ便利なプラグインがsrc/pluginsの中に入っています。
プラグインの読み込みは、
```
<script type="text/javascript" src="src/enchant.js"></script>
```
の後に記述しましょう。

もう1つの原因は、main.jsでPadをaddChild()しようとしていた変数名が違ったので変数名を修正しました。

Padを表示するようになりましたが、うまく動作しません。
本来はうまく動作する状態にしてプルリクを送りますが、この部分もやってしまうと面白くないので
修正に挑戦してみてください。main.jsの236行目あたりが怪しいです。


- preload部分を見やすく修正。

preload()の引数は配列なので複数指定が可能です。
そこで、画像系とBGM/SE系でpreloadをまとめてみました。
これで画像やBGM/SEを追加するときにファイル名を追記するだけで済みます。

